### PR TITLE
Use HEAD_REF for the target branch name

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check branch prefix
         id: branch_prefix_check
         run: |
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           MATCHED=false
           PREFIX=""
           for prefix in $(echo ${{ env.prefixes }} | tr "," "\n"); do
@@ -41,7 +41,7 @@ jobs:
       - name: Check branch name format
         id: branch_name_check
         run: |
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           PREFIX="${{ steps.branch_prefix_check.outputs.prefix }}"
           REST="${BRANCH_NAME#$PREFIX}"
           PATTERN="${{ env.pattern }}"


### PR DESCRIPTION
The child workflow trigger event needed to be changed to run on pull requests instead of push.

This means that we need to use
`BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}` 
instead of 
`BRANCH_NAME="${GITHUB_REF#refs/heads/}"` 
to get the right name for the source branch.